### PR TITLE
Remove unused variable

### DIFF
--- a/handler-pullrequest.js
+++ b/handler-pullrequest.js
@@ -163,7 +163,6 @@ class PullRequestHandler {
     static handleStatusChange({
         owner,
         repo,
-        state,
         sha,
     }) {
         return pullRequestManager.getPullRequestInfoBySha(owner, repo, sha)

--- a/routes-webhook.js
+++ b/routes-webhook.js
@@ -40,7 +40,6 @@ router.post('/', (req, res, next) => {
         owner,
         repo,
         sha,
-        state,
     })
         .then(() => res.json(`Status of ${sha} ${state}`));
 });

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,8 @@ export NEW_RELIC_LOG=stdout
 export NEW_RELIC_NO_CONFIG_FILE=true
 export DATADOG_API_KEY=fake
 export APP_ORIGIN=fake
+export PORT=3333
+
 if [ -z "$MONGO_URL" ]; then
     export MONGO_URL=mongodb://localhost/branch-bookkeeper-test
 fi

--- a/test/testPullRequestHandler.js
+++ b/test/testPullRequestHandler.js
@@ -11,7 +11,6 @@ const pullRequestSynchronizedFixture = require('./fixtures/pull_request.synchron
 const pullRequestClosedFixture = require('./fixtures/pull_request.closed.json');
 const pullRequestMergedFixture = require('./fixtures/pull_request.merged.json');
 const pullRequestInfoFixture = require('./fixtures/pull_request.info.json');
-const statusFailurePayload = require('./fixtures/status.failure.json');
 const statusSuccessPayload = require('./fixtures/status.success.json');
 const queueItemFixture = require('./fixtures/queue.item.json');
 const owner = 'branch-bookkeeper';

--- a/test/testPullRequestHandler.js
+++ b/test/testPullRequestHandler.js
@@ -210,7 +210,7 @@ suite('PullRequestHandler', () => {
                             branch,
                             pullRequestNumber,
                             username,
-                            state: GitHub.STATUS_SUCCESS,
+                            state,
                         },
                         topic: 'send.checks',
                     });

--- a/test/testPullRequestHandler.js
+++ b/test/testPullRequestHandler.js
@@ -36,11 +36,7 @@ suite('PullRequestHandler', () => {
             this.skip();
         }
         gitHubSpy = sinon.stub(GitHub, 'updatePullRequestStatus').resolves('');
-        gitHubHashSpy = sinon.stub(GitHub, 'getHashStatus')
-            .onFirstCall()
-            .resolves({ state: GitHub.STATUS_SUCCESS })
-            .onSecondCall()
-            .resolves({ state: GitHub.STATUS_FAILURE });
+        gitHubHashSpy = sinon.stub(GitHub, 'getHashStatus').resolves({ state: GitHub.STATUS_PENDING });
         queueManagerGetItemSpy = sinon.stub(queueManager, 'getItem').resolves(queueItemFixture);
         queueManagerGetFirstItemSpy = sinon.stub(queueManager, 'getFirstItem').resolves(queueItemFixture);
         queueManagerGetItemsSpy = sinon.stub(queueManager, 'getItems').resolves([queueItemFixture]);
@@ -185,6 +181,7 @@ suite('PullRequestHandler', () => {
 
     [GitHub.STATUS_SUCCESS, GitHub.STATUS_FAILURE].forEach(status => {
         test(`Handle status change success for first item GH reports ${status}`, () => {
+            gitHubHashSpy.resolves({ state });
             const {
                 sha,
                 installation: { id: installationId },
@@ -222,7 +219,6 @@ suite('PullRequestHandler', () => {
     });
 
     test('Handle status change success for first item GH reports pending', () => {
-        gitHubHashSpy.onFirstCall().resolves({ state: GitHub.STATUS_PENDING });
         const {
             sha,
             installation: { id: installationId },

--- a/test/testPullRequestHandler.js
+++ b/test/testPullRequestHandler.js
@@ -187,7 +187,6 @@ suite('PullRequestHandler', () => {
     [GitHub.STATUS_SUCCESS, GitHub.STATUS_FAILURE].forEach(status => {
         test(`Handle status change success for first item GH reports ${status}`, () => {
             const {
-                state,
                 sha,
                 installation: { id: installationId },
                 repository: { name: repo, owner: { login: owner } },
@@ -196,7 +195,6 @@ suite('PullRequestHandler', () => {
             return pullRequestHandler.handleStatusChange({
                 owner,
                 repo,
-                state,
                 sha,
             })
                 .then(() => {
@@ -227,7 +225,6 @@ suite('PullRequestHandler', () => {
     test('Handle status change success for first item GH reports pending', () => {
         gitHubHashSpy.onFirstCall().resolves({ state: GitHub.STATUS_PENDING });
         const {
-            state,
             sha,
             installation: { id: installationId },
             repository: { name: repo, owner: { login: owner } },
@@ -235,7 +232,6 @@ suite('PullRequestHandler', () => {
         return pullRequestHandler.handleStatusChange({
             owner,
             repo,
-            state,
             sha,
         })
             .then(() => {
@@ -252,12 +248,11 @@ suite('PullRequestHandler', () => {
     });
 
     test('Handle status change empty queue', () => {
-        const { state, sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
+        const { sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
         queueManagerGetFirstItemSpy.resolves(undefined);
         return pullRequestHandler.handleStatusChange({
             owner,
             repo,
-            state,
             sha,
         })
             .then(() => {
@@ -269,7 +264,7 @@ suite('PullRequestHandler', () => {
     });
 
     test('Handle status change item not in queue', () => {
-        const { state, sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
+        const { sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
         const firstItem = {
             ...queueItemFixture,
             pullRequestNumber: 2,
@@ -278,7 +273,6 @@ suite('PullRequestHandler', () => {
         return pullRequestHandler.handleStatusChange({
             owner,
             repo,
-            state,
             sha,
         })
             .then(() => {
@@ -290,7 +284,7 @@ suite('PullRequestHandler', () => {
     });
 
     test('Handle status change item not first', () => {
-        const { state, sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
+        const { sha, repository: { name: repo, owner: { login: owner } } } = statusSuccessPayload;
         const firstItem = {
             ...queueItemFixture,
             pullRequestNumber: 2,
@@ -299,7 +293,6 @@ suite('PullRequestHandler', () => {
         return pullRequestHandler.handleStatusChange({
             owner,
             repo,
-            state,
             sha,
         })
             .then(() => {

--- a/test/testPullRequestHandler.js
+++ b/test/testPullRequestHandler.js
@@ -179,8 +179,8 @@ suite('PullRequestHandler', () => {
         });
     });
 
-    [GitHub.STATUS_SUCCESS, GitHub.STATUS_FAILURE].forEach(status => {
-        test(`Handle status change success for first item GH reports ${status}`, () => {
+    [GitHub.STATUS_SUCCESS, GitHub.STATUS_FAILURE].forEach(state => {
+        test(`Handle status change success for first item GH reports ${state}`, () => {
             gitHubHashSpy.resolves({ state });
             const {
                 sha,


### PR DESCRIPTION
There's no need to pass `state` value to determine the received commit state since we always do the same thing