### PR TITLE
Fix queue manager getters

### DIFF
--- a/manager-queue.js
+++ b/manager-queue.js
@@ -121,9 +121,11 @@ class QueueManager {
                     _id: `${owner}-${repo}-${branch}`,
                 },
                 {
-                    _id: false,
-                    queue: {
-                        $elemMatch: { pullRequestNumber },
+                    projection: {
+                        _id: false,
+                        queue: {
+                            $elemMatch: { pullRequestNumber },
+                        },
                     },
                 }
             ))

--- a/manager-queue.js
+++ b/manager-queue.js
@@ -101,11 +101,13 @@ class QueueManager {
                     _id: `${owner}-${repo}-${branch}`,
                 },
                 {
-                    _id: false,
-                    owner: false,
-                    repo: false,
-                    queue: {
-                        $slice: numberOfItems,
+                    projection: {
+                        _id: false,
+                        owner: false,
+                        repo: false,
+                        queue: {
+                            $slice: numberOfItems,
+                        },
                     },
                 }
             ))

--- a/test/testQueueManager.js
+++ b/test/testQueueManager.js
@@ -26,12 +26,29 @@ suite('QueueManager', () => {
     });
 
     test('Get items', () => {
-        return queueManager.getItems(owner, repo, branch)
+        const secondItem = { ...queueItem, pullRequestNumber: queueItem.pullRequestNumber + 1 };
+        return queueManager.addItem(owner, repo, branch, queueItem)
+            .then(() => queueManager.addItem(owner, repo, branch, secondItem))
+            .then(() => queueManager.getItems(owner, repo, branch))
             .then(items => {
                 assert.isArray(items);
-                assert.empty(items);
-                assert.lengthOf(items, 0);
-                assert.deepEqual([], items);
+                assert.notEmpty(items);
+                assert.lengthOf(items, 2);
+                assert.deepEqual([queueItem, secondItem], items);
+            });
+    });
+
+    test('Get specific number of items', () => {
+        const secondItem = { ...queueItem, pullRequestNumber: queueItem.pullRequestNumber + 1 };
+        const numberOfItems = 1;
+        return queueManager.addItem(owner, repo, branch, queueItem)
+            .then(() => queueManager.addItem(owner, repo, branch, secondItem))
+            .then(() => queueManager.getItems(owner, repo, branch, numberOfItems))
+            .then(items => {
+                assert.isArray(items);
+                assert.notEmpty(items);
+                assert.lengthOf(items, numberOfItems);
+                assert.deepEqual([queueItem], items);
             });
     });
 

--- a/test/testQueueManager.js
+++ b/test/testQueueManager.js
@@ -63,10 +63,15 @@ suite('QueueManager', () => {
             });
     });
 
-    test('Get item', () => {
+    test('Get specific item', () => {
+        const secondItem = { ...queueItem, pullRequestNumber: queueItem.pullRequestNumber + 1 };
+
         return queueManager.addItem(owner, repo, branch, queueItem)
-            .then(() => queueManager.getItem(owner, repo, branch, queueItem.pullRequestNumber))
-            .then(item => assert.deepEqual(queueItem, item));
+            .then(() => queueManager.addItem(owner, repo, branch, secondItem))
+            .then(() => queueManager.getItem(owner, repo, branch, secondItem.pullRequestNumber))
+            .then(item => {
+                assert.deepEqual(secondItem, item);
+            });
     });
 
     test('Get not existing item', () => {


### PR DESCRIPTION
Ref. [findOne](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne)

`node-mongodb` driver accepts a `projection` (previously `fields`) parameter to select which fields project when using `findOne`.